### PR TITLE
Revert "Update loadgen"

### DIFF
--- a/src/microservice-kafka-order/src/main/java/com/ewolff/microservice/order/logic/SpringRestDataConfig.java
+++ b/src/microservice-kafka-order/src/main/java/com/ewolff/microservice/order/logic/SpringRestDataConfig.java
@@ -4,15 +4,23 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapter;
 
 import com.ewolff.microservice.order.customer.Customer;
 import com.ewolff.microservice.order.item.Item;
 
 @Configuration
-public class SpringRestDataConfig implements RepositoryRestConfigurer {
-	@Override
-	public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config, CorsRegistry cors) {
-		config.exposeIdsFor(Order.class, Item.class, Customer.class);	
+class SpringRestDataConfig extends RepositoryRestConfigurerAdapter {
+
+	@Bean
+	public RepositoryRestConfigurer repositoryRestConfigurer() {
+
+		return new RepositoryRestConfigurerAdapter() {
+			@Override
+			public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
+				config.exposeIdsFor(Order.class, Item.class, Customer.class);
+			}
+		};
 	}
+
 }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.6</version>
+		<version>2.3.4.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
This reverts commit 35355d6acee54032c046161db2f87db3792a1732.
Only thing we don't change is the locustfile change in that diff.

The original change made it so that you couldn't modify 1 of the services for testing features. This diff makes that possible again.

Tested by building the orders service and setting as image for order service inside of https://github.com/pixie-io/pixie/blob/main/demos/kafka/kafka.yaml